### PR TITLE
fix vlimits code

### DIFF
--- a/indimail-x/ProcessInFifo.c
+++ b/indimail-x/ProcessInFifo.c
@@ -1,5 +1,8 @@
 /*
  * $Log: ProcessInFifo.c,v $
+ * Revision 1.20  2024-05-27 22:52:54+05:30  Cprogrammer
+ * initialize struct vlimits
+ *
  * Revision 1.19  2024-05-17 16:25:48+05:30  mbhangui
  * fix discarded-qualifier compiler warnings
  *
@@ -134,7 +137,7 @@
 #include "FifoCreate.h"
 
 #ifndef	lint
-static char     sccsid[] = "$Id: ProcessInFifo.c,v 1.19 2024-05-17 16:25:48+05:30 mbhangui Exp mbhangui $";
+static char     sccsid[] = "$Id: ProcessInFifo.c,v 1.20 2024-05-27 22:52:54+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 int             user_query_count, relay_query_count, pwd_query_count, alias_query_count;
@@ -929,7 +932,7 @@ ProcessInFifo(int instNum)
 	time_t          prev_time = 0l;
 	substdio        ssin;
 #ifdef ENABLE_DOMAIN_LIMITS
-	struct vlimits  limits;
+	struct vlimits  limits = { 0 };
 #endif
 
 	_debug = (env_get("DEBUG") ? 1 : 0);

--- a/indimail-x/VlimitInLookup.c
+++ b/indimail-x/VlimitInLookup.c
@@ -1,5 +1,8 @@
 /*
  * $Log: VlimitInLookup.c,v $
+ * Revision 1.3  2024-05-27 22:53:54+05:30  Cprogrammer
+ * initialize struct vlimits
+ *
  * Revision 1.2  2024-05-17 16:25:48+05:30  mbhangui
  * fix discarded-qualifier compiler warnings
  *
@@ -12,7 +15,7 @@
 #endif
 
 #ifndef	lint
-static char     sccsid[] = "$Id: VlimitInLookup.c,v 1.2 2024-05-17 16:25:48+05:30 mbhangui Exp mbhangui $";
+static char     sccsid[] = "$Id: VlimitInLookup.c,v 1.3 2024-05-27 22:53:54+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 #ifdef ENABLE_DOMAIN_LIMITS
@@ -39,7 +42,7 @@ VlimitInLookup(const char *email, struct vlimits *lim)
 	static stralloc user = {0}, domain = {0};
 	const char     *real_domain;
 #ifdef ENABLE_DOMAIN_LIMITS
-	struct vlimits  limits;
+	struct vlimits  limits = { 0 };
 #endif
 
 #ifdef CLUSTERED_SITE

--- a/indimail-x/authindi.c
+++ b/indimail-x/authindi.c
@@ -1,5 +1,5 @@
 /*
- * $Id: authindi.c,v 1.19 2024-05-17 16:25:48+05:30 mbhangui Exp mbhangui $
+ * $Id: authindi.c,v 1.20 2024-05-27 22:50:29+05:30 Cprogrammer Exp mbhangui $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -57,7 +57,7 @@
 #define WARN  "authindi: warn: "
 
 #ifndef lint
-static char     sccsid[] = "$Id: authindi.c,v 1.19 2024-05-17 16:25:48+05:30 mbhangui Exp mbhangui $";
+static char     sccsid[] = "$Id: authindi.c,v 1.20 2024-05-27 22:50:29+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 static stralloc tmpbuf = {0};
@@ -317,7 +317,7 @@ main(int argc, char **argv)
 	struct passwd  *pw;
 #ifdef ENABLE_DOMAIN_LIMITS
 	time_t          curtime;
-	struct vlimits  limits;
+	struct vlimits  limits = { 0 };
 #endif
 
 	if (argc < 2)
@@ -684,6 +684,9 @@ main(int argc, char **argv)
 
 /*
  * $Log: authindi.c,v $
+ * Revision 1.20  2024-05-27 22:50:29+05:30  Cprogrammer
+ * initialize struct vlimits
+ *
  * Revision 1.19  2024-05-17 16:25:48+05:30  mbhangui
  * fix discarded-qualifier compiler warnings
  *

--- a/indimail-x/authpgsql.c
+++ b/indimail-x/authpgsql.c
@@ -1,5 +1,8 @@
 /*
  * $Log: authpgsql.c,v $
+ * Revision 1.11  2024-05-27 22:51:10+05:30  Cprogrammer
+ * initialize struct vlimits
+ *
  * Revision 1.10  2023-08-04 22:39:42+05:30  Cprogrammer
  * include errno.h, authmethods.h, subfd.h
  *
@@ -73,7 +76,7 @@
 #include "runcmmd.h"
 
 #ifndef lint
-static char     sccsid[] = "$Id: authpgsql.c,v 1.10 2023-08-04 22:39:42+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: authpgsql.c,v 1.11 2024-05-27 22:51:10+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 #ifdef HAVE_PGSQL
@@ -108,7 +111,7 @@ pg_getpw(char *user, char *domain)
 	int             i;
 	PGresult       *pgres;
 #ifdef ENABLE_DOMAIN_LIMITS
-	struct vlimits  limits;
+	struct vlimits  limits = { 0 };
 #endif
 
 	lowerit(user);
@@ -199,7 +202,7 @@ main(int argc, char **argv)
 	struct passwd  *pw;
 #ifdef ENABLE_DOMAIN_LIMITS
 	time_t          curtime;
-	struct vlimits  limits;
+	struct vlimits  limits = { 0 };
 #endif
 
 	if (argc < 2)

--- a/indimail-x/doc/ChangeLog
+++ b/indimail-x/doc/ChangeLog
@@ -20,6 +20,16 @@ Release @version@-@release@ Start 02/05/2024 End XX/XX/XXXX
 - 24/05/2024
 13. vsetuserquota.c: print current usage in bytes on stdout
 14. setuserquota.c: changed return type of setuserquota to 64bit int
+- 28/05/2024
+15.  ProcessInFifo.c, VlimitInLookup.c, authindi.c, authpgsql.c, iauth.c,
+     sql_getpw.c, vadduser.c, vchkpass.c, vlimit.c, vmoduser.c,
+     vsetuserquota.c: initialize struct vlimits
+16. limits.c: fix data types to fix stack smashing
+17. vlimits.h: changed data types to long
+18. vlimit.c: added -T option to toggle bit field
+19. vlimit.c: fixed data types
+20. inquerytest: change data type to long
+21. vadduser.c: fix .domain_limits path
 
 * Mon Jan 01 2024 09:24:41 +0000 Manvendra Bhangui <indimail-virtualdomains@indimail.org> 3.4.6-1.1%{?dist}
 Release 3.4.6-1.1 Start 09/09/2023 End 01/01/2024

--- a/indimail-x/iauth.c
+++ b/indimail-x/iauth.c
@@ -1,5 +1,5 @@
 /*
- * $Id: iauth.c,v 1.10 2024-05-17 16:25:48+05:30 mbhangui Exp mbhangui $
+ * $Id: iauth.c,v 1.11 2024-05-27 22:51:20+05:30 Cprogrammer Exp mbhangui $
  *
  * authenticate.c - Generic PAM Authentication module for pam_multi
  * Copyright (C) <2008-2023>  Manvendra Bhangui <manvendra@indimail.org>
@@ -81,7 +81,7 @@
 #include "common.h"
 
 #ifndef lint
-static char     sccsid[] = "$Id: iauth.c,v 1.10 2024-05-17 16:25:48+05:30 mbhangui Exp mbhangui $";
+static char     sccsid[] = "$Id: iauth.c,v 1.11 2024-05-27 22:51:20+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 static int      defaultTask(char *, char *, struct passwd *, char *, int);
@@ -223,7 +223,7 @@ i_acctmgmt(char *email, char *service, int *size, int *nitems, int debug)
 	MYSQL_RES      *res;
 	MYSQL_ROW       row;
 #ifdef ENABLE_DOMAIN_LIMITS
-	struct vlimits  limits;
+	struct vlimits  limits = { 0 };
 #endif
 
 	if (nitems)
@@ -470,6 +470,9 @@ defaultTask(char *email, char *TheDomain, struct passwd *pw, char *service, int 
 
 /*
  * $Log: iauth.c,v $
+ * Revision 1.11  2024-05-27 22:51:20+05:30  Cprogrammer
+ * initialize struct vlimits
+ *
  * Revision 1.10  2024-05-17 16:25:48+05:30  mbhangui
  * fix discarded-qualifier compiler warnings
  *

--- a/indimail-x/indimail.9
+++ b/indimail-x/indimail.9
@@ -1675,7 +1675,7 @@ vdominfo(1)        - Print domain information
 printdir(1)        - Print domain directory structure layout
 .sp -1
 .IP \n+[step]
-vmoddomlimits(1)   - Modify domain limits
+vlimit(1)   - Modify domain limits
 .sp -1
 .IP \n+[step]
 vadduser(1)        - Add a user

--- a/indimail-x/inquerytest.c
+++ b/indimail-x/inquerytest.c
@@ -1,5 +1,8 @@
 /*
  * $Log: inquerytest.c,v $
+ * Revision 1.11  2024-05-27 22:51:37+05:30  Cprogrammer
+ * change data type to long
+ *
  * Revision 1.10  2023-06-08 17:48:31+05:30  Cprogrammer
  * renamed fifo directory from FIFODIR to INFIFODIR
  *
@@ -76,7 +79,7 @@
 #include "vlimits.h"
 
 #ifndef	lint
-static char     sccsid[] = "$Id: inquerytest.c,v 1.10 2023-06-08 17:48:31+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: inquerytest.c,v 1.11 2024-05-27 22:51:37+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 #define FATAL   "inquerytest: fatal: "
@@ -114,11 +117,11 @@ print_limits(struct vlimits *limits)
 	subprintfe(subfdout, "inquerytest", "Max Domain Messages  : %13lu\n", limits->maxmsgcount);
 	subprintfe(subfdout, "inquerytest", "Default User Quota   : %13ld\n", limits->defaultquota);
 	subprintfe(subfdout, "inquerytest", "Default User Messages: %13lu\n", limits->defaultmaxmsgcount);
-	subprintfe(subfdout, "inquerytest", "Max Pop Accounts     : %13d\n", limits->maxpopaccounts);
-	subprintfe(subfdout, "inquerytest", "Max Aliases          : %13d\n", limits->maxaliases);
-	subprintfe(subfdout, "inquerytest", "Max Forwards         : %13d\n", limits->maxforwards);
-	subprintfe(subfdout, "inquerytest", "Max Autoresponders   : %13d\n", limits->maxautoresponders);
-	subprintfe(subfdout, "inquerytest", "Max Mailinglists     : %13d\n", limits->maxmailinglists);
+	subprintfe(subfdout, "inquerytest", "Max Pop Accounts     : %13ld\n", limits->maxpopaccounts);
+	subprintfe(subfdout, "inquerytest", "Max Aliases          : %13ld\n", limits->maxaliases);
+	subprintfe(subfdout, "inquerytest", "Max Forwards         : %13ld\n", limits->maxforwards);
+	subprintfe(subfdout, "inquerytest", "Max Autoresponders   : %13ld\n", limits->maxautoresponders);
+	subprintfe(subfdout, "inquerytest", "Max Mailinglists     : %13ld\n", limits->maxmailinglists);
 	out("inquerytest", "\n");
 	subprintfe(subfdout, "inquerytest", "GID Flags:\n");
 	subprintfe(subfdout, "inquerytest", "  %s\n", limits->disable_imap ? "NO_IMAP" : "IMAP");

--- a/indimail-x/sql_getpw.c
+++ b/indimail-x/sql_getpw.c
@@ -1,5 +1,5 @@
 /*
- * $Id: sql_getpw.c,v 1.5 2024-05-17 16:25:48+05:30 mbhangui Exp mbhangui $
+ * $Id: sql_getpw.c,v 1.6 2024-05-27 22:53:02+05:30 Cprogrammer Exp mbhangui $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -27,7 +27,7 @@
 #include "strToPw.h"
 
 #ifndef	lint
-static char     sccsid[] = "$Id: sql_getpw.c,v 1.5 2024-05-17 16:25:48+05:30 mbhangui Exp mbhangui $";
+static char     sccsid[] = "$Id: sql_getpw.c,v 1.6 2024-05-27 22:53:02+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 #ifdef QUERY_CACHE
@@ -88,7 +88,7 @@ sql_getpw(const char *user, const char *domain)
 	static stralloc _user = {0}, _domain = {0};
 	static stralloc IUser = {0}, IDomain = {0};
 #ifdef ENABLE_DOMAIN_LIMITS
-	struct vlimits  limits;
+	struct vlimits  limits = { 0 };
 #endif
 
 	if (!domain || !*domain || !user || !*user)
@@ -222,6 +222,9 @@ sql_getpw_cache(char cache_switch)
 
 /*
  * $Log: sql_getpw.c,v $
+ * Revision 1.6  2024-05-27 22:53:02+05:30  Cprogrammer
+ * initialize struct vlimits
+ *
  * Revision 1.5  2024-05-17 16:25:48+05:30  mbhangui
  * fix discarded-qualifier compiler warnings
  *

--- a/indimail-x/tests/testindimail-virtual
+++ b/indimail-x/tests/testindimail-virtual
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# $Id: testindimail-virtual,v 1.27 2024-05-24 14:53:22+05:30 Cprogrammer Exp mbhangui $
+# $Id: testindimail-virtual,v 1.28 2024-05-28 00:23:38+05:30 Cprogrammer Exp mbhangui $
 #
 start=$(date +'%s')
 user=$(whoami)
@@ -37,6 +37,7 @@ tmpfifodir=$testdir/inquery
 logdir=$testdir/logs
 bindir=/usr/bin
 sbindir=/usr/sbin
+tmpdir=$testdir/tmp
 SOFT_MEM=104857600
 confsplit=23
 HOSTNAME=$(uname -n)
@@ -548,6 +549,7 @@ setup_svscan()
 	echo inlookup           > $servicedir/inlookup.infifo/variables/MYSQL_READ_GROUP
 	echo                    > $servicedir/inlookup.infifo/variables/PASSWD_CACHE
 	echo                    > $servicedir/inlookup.infifo/variables/QUERY_CACHE
+	echo 1                  > $servicedir/inlookup.infifo/variables/DOMAIN_LIMITS
 	(
 	echo "#!/bin/sh"
 	echo "count=5"
@@ -694,7 +696,7 @@ do_setup()
 		mysql=/usr/bin/mysql
 	fi
 	# basic setup for maildir, assign config and queue
-	$sudo /bin/rm -rf $logdir
+	$sudo /bin/rm -rf $logdir $tmpdir
 	mkdir -p $logdir/setup
 	mkdir -p $logdir/qremote
 	mkdir -p $logdir/gsasl
@@ -708,6 +710,7 @@ do_setup()
 	mkdir -p $logdir/imapd-ssl
 	mkdir -p $logdir/pop3d-ssl
 	mkdir -p $logdir/tcpclient
+	mkdir -p $tmpdir
 	setup_maildir
 	setup_assign
 	setup_queue
@@ -771,7 +774,7 @@ create_plain_user()
 		CONTROLDIR=$cntrldir \
 		DOMAINDIR=$qmaildir \
 		SERVICEDIR=$servicedir \
-		vadduser -d $extra $1 $2 >> $logdir/setup/vadduser.log 2>&1
+		vadduser -d $extra $1 $2 > $logdir/setup/vadduser.log 2>&1
 	if [ $? -eq 0 ] ; then
 		tm2=$(date +"%s.%4N")
 		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
@@ -1565,6 +1568,102 @@ delete_relay()
 	return $?
 }
 
+auth_pop3()
+{
+	(
+	echo "#!/bin/sh"
+	echo "exec 0<&6"
+	echo "exec 1>&7"
+	echo "read line"
+	echo "printf \"%s\n\" \"\$line\" 1>&2"
+	if [ "$3" = "PLAIN" ] ; then
+		b64=$(printf "\0$1\0$2" | base64)
+		echo "printf \"AUTH PLAIN\r\n\" 1>&2"
+		echo "printf \"AUTH PLAIN\r\n\""
+		echo "read line"
+		echo "printf \"%s\n\" \"\$line\" 1>&2"
+		echo "printf \"$b64\r\n\" 1>&2"
+		echo "printf \"$b64\r\n\""
+	elif [ "$3" = "CRAM-MD5" -o "$3" = "CRAM-SHA1" -o "$3" = "CRAM-SHA256" ] ; then
+		echo "printf \"AUTH $3\r\n\" 1>&2"
+		echo "printf \"AUTH $3\r\n\""
+		echo "read line"
+		echo "line=\$(echo \$line | cut -c3- | sed -e 's/\r//g')"
+		echo "b64=\$($authcram -t $3 $1 $2 \$line | sed -e 's/\r//g')"
+		echo "printf \"%s\r\n\" \"\$b64\" 1>&2"
+		echo "printf \"%s\r\n\" \"\$b64\""
+	fi
+	echo "read line"
+	echo "printf \"%s\n\" \"\$line\" 1>&2"
+	echo "printf \"%s\" \"\$line\" | grep -E \"+OK logged in.\" >/dev/null 2>&1"
+	echo "if [ \$? -ne 0 ] ; then"
+	echo "	echo \"Failed to login\" 1>&2"
+	echo "	exit 1"
+	echo "fi"
+	echo "printf \"LIST\r\n\" 1>&2"
+	echo "printf \"LIST\r\n\""
+	echo "read line"
+	echo "printf \"%s\" \"\$line\" |grep -E \"+OK POP3 clients that break here, they violate STD53.\" > /dev/null"
+	echo "if [ \$? -ne 0 ] ; then"
+	echo "	echo \"LIST command failed\" 1>&2"
+	echo "	exit 1"
+	echo "fi"
+	echo "read line"
+	echo "printf \"%s\n\" \"\$line\" 1>&2"
+	echo "octets=\$(printf \"%s\n\" \"\$line\"|awk '{print \$2}')"
+	echo "while true"
+	echo "do"
+	echo "	read line"
+	echo "	if [ -z \"\$line\" ] ; then"
+	echo "		break"
+	echo "	fi"
+	echo "	printf \"%s\n\" \"\$line\" 1>&2"
+	echo "	line=\$(echo \"\$line\"|tr -d '\r')"
+	echo "	if [ -z \"\$line\" -o \"\$line\" = \".\" ] ; then"
+	echo "		break"
+	echo "	fi"
+	echo "done"
+	echo "printf \"RETR 1\r\n\" 1>&2"
+	echo "printf \"RETR 1\r\n\""
+	echo "read line"
+	echo "printf \"%s\n\" \"\$line\" 1>&2"
+	echo "printf \"%s\" \"\$line\" | grep -E \"+OK .* octets follow.\" > /dev/null"
+	echo "if [ \$? -ne 0 ] ; then"
+	echo "	echo \"RETR command failed\" 1>&2"
+	echo "	exit 1"
+	echo "fi"
+	echo "found=0"
+	echo "while true"
+	echo "do"
+	echo "	read line"
+	echo "	if [ -z \"\$line\" ] ; then"
+	echo "		break"
+	echo "	fi"
+	echo "	printf \"%s\n\" \"\$line\" 1>&2"
+	echo "	line=\$(echo \"\$line\"|tr -d '\r')"
+	echo "	if [ \"\$line\" = \".\" ] ; then"
+	echo "		break"
+	echo "	fi"
+	echo "	echo \"\$line\" | grep \"This is a test mailing\" > /dev/null"
+	echo "	if [ \$? -eq 0 ] ; then"
+	echo "		found=1"
+	echo "	fi"
+	echo "done"
+	echo "printf \"QUIT\r\n\""
+	echo "read line"
+	echo "printf \"%s\n\" \"\$line\" 1>&2"
+	echo "if [ \$found -eq 1 ] ; then"
+	echo "	exit 0"
+	echo "else"
+	echo "	exit 1"
+	echo "fi"
+	) > $testdir/tcpclient.pop3
+	chmod +x $testdir/tcpclient.pop3
+	check_service pop3d
+	tcpclient -a 10 -vDHR 0 1100 $testdir/tcpclient.pop3
+	return $?
+}
+
 test_pop3()
 {
 	tm1=$(date +"%s.%4N")
@@ -1665,7 +1764,7 @@ test_pop3()
 	chmod +x $testdir/tcpclient.pop3
 	check_service pop3d
 	tm1=$(date +"%s.%4N")
-	tcpclient -a 10 -vDHR 0 1100 /tmp/qmail-test/tcpclient.pop3 2>$logdir/pop3d/pop3d.log
+	tcpclient -a 10 -vDHR 0 1100 $testdir/tcpclient.pop3 2>$logdir/pop3d/pop3d.log
 	if [ $? -eq 0 ] ; then
 		tm2=$(date +"%s.%4N")
 		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
@@ -1739,7 +1838,7 @@ test_pop3()
 	tm1=$(date +"%s.%4N")
 	sudo $setuidgid -g qcerts $user tcpclient -a 10 -f $cntrldir/$fn \
 		-n $certdir/clientcert.pem -vDHR 0 9950 \
-		/tmp/qmail-test/tcpclient.pop3 2>$logdir/pop3d-ssl/pop3d-ssl.log
+		$testdir/tcpclient.pop3 2>$logdir/pop3d-ssl/pop3d-ssl.log
 	if [ $? -eq 0 ] ; then
 		tm2=$(date +"%s.%4N")
 		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
@@ -1787,6 +1886,93 @@ test_pop3()
 		[ -z "$failed" ] && failed="open relay pop3s" || failed="$failed, open relay pop3s"
 		[ $continue_on_err -eq 0 ] && exit 1 || return 0
 	fi
+}
+
+auth_imap()
+{
+	b64=$(printf "\0$1\0$2" | base64)
+	(
+	echo "#!/bin/sh"
+	echo "exec 0<&6"
+	echo "exec 1>&7"
+	echo "read key"
+	echo "printf \"%s\n\" \"\$key\" 1>&2"
+	if [ "$3" = "PLAIN" ] ; then
+		echo "printf \"a1 AUTHENTICATE PLAIN\r\n\" 1>&2"
+		echo "printf \"a1 AUTHENTICATE PLAIN\r\n\""
+		echo "read line"
+		echo "printf \"%s\n\" \"\$line\" 1>&2"
+		echo "printf \"%s\r\n\" $b64 1>&2"
+		echo "printf \"%s\r\n\" $b64"
+	elif [ "$3" = "CRAM-MD5" -o "$3" = "CRAM-SHA1" -o "$3" = "CRAM-SHA256" ] ; then
+		echo "printf \"a1 AUTHENTICATE $3\r\n\" 1>&2"
+		echo "printf \"a1 AUTHENTICATE $3\r\n\""
+		echo "read line"
+		echo "line=\$(echo \$line | cut -c3- | sed -e 's/\r//g')"
+		echo "b64=\$($authcram -t $3 $1 $2 \$line | sed -e 's/\r//g')"
+		echo "printf \"%s\r\n\" \"\$b64\" 1>&2"
+		echo "printf \"%s\r\n\" \"\$b64\""
+	fi
+	echo "read key"
+	echo "printf \"%s\" \"\$key\" |grep \"a1 OK LOGIN Ok.\" >/dev/null"
+	echo "if [ \$? -ne 0 ] ; then"
+	echo "	printf \"%s\n\" \"\$key\" 1>&2"
+	echo "	echo \"LOGIN Failed\" 1>&2"
+	echo "	exit 1"
+	echo "else"
+	echo "	printf \"%s\n\" \"\$key\" 1>&2"
+	echo "fi"
+	echo "printf \"a1 select inbox\r\n\""
+	echo "while true"
+	echo "do"
+	echo "	read line"
+	echo "	if [ -z \"\$line\" ] ; then"
+	echo "		break"
+	echo "	fi"
+	echo "	t=\$(echo \"\$line\" | cut -d' ' -f1)"
+	echo "	if [ \"\$t\" = \"*\" ] ; then"
+	echo "		echo \"\$line\" 1>&2"
+	echo "		continue"
+	echo "	elif [ \"\$t\" = \"a1\" ] ; then"
+	echo "		break"
+	echo "	else"
+	echo "		echo \"\$line\" 1>&2"
+	echo "	fi"
+	echo "done"
+	echo ""
+	echo "printf \"a1 fetch 1 RFC822\r\n\""
+	echo "found=0"
+	echo "while true"
+	echo "do"
+	echo "	read line"
+	echo "	if [ -z \"\$line\" ] ; then"
+	echo "		break"
+	echo "	fi"
+	echo "	echo \"\$line\" | grep \"a1 OK FETCH completed.\" > /dev/null"
+	echo "	if [ \$? -eq 0 ] ; then"
+	echo "		break"
+	echo "	fi"
+	echo "	echo \"\$line\" | grep \"This is a test mailing\" > /dev/null"
+	echo "	if [ \$? -eq 0 ] ; then"
+	echo "		found=1"
+	echo "	fi"
+	echo "	echo \"\$line\" 1>&2"
+	echo "done"
+	echo "printf \"a1 logout\r\n\""
+	echo "read line"
+	echo "printf \"%s\n\" \"\$line\""
+	echo "if [ \$found -eq 1 ] ; then"
+	echo "	exit 0"
+	echo "else"
+	echo "	exit 1"
+	echo "fi"
+	) > $testdir/tcpclient.imap
+	chmod +x $testdir/tcpclient.imap
+	check_service imapd 3
+	chmod +x $testdir/tcpclient.imap
+	check_service imapd 3
+	tcpclient -a 10 -vDHR 0 1430 $testdir/tcpclient.imap
+	return $?
 }
 
 test_imap()
@@ -1878,7 +2064,7 @@ test_imap()
 	chmod +x $testdir/tcpclient.imap
 	check_service imapd 3
 	tm1=$(date +"%s.%4N")
-	tcpclient -a 10 -vDHR 0 1430 /tmp/qmail-test/tcpclient.imap 2>$logdir/imapd/imapd.log
+	tcpclient -a 10 -vDHR 0 1430 $testdir/tcpclient.imap 2>$logdir/imapd/imapd.log
 	if [ $? -eq 0 ] ; then
 		tm2=$(date +"%s.%4N")
 		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
@@ -1950,7 +2136,7 @@ test_imap()
 	check_service imapd-ssl 3
 	tm1=$(date +"%s.%4N")
 	sudo $setuidgid -g qcerts $user tcpclient -a 10 -f $cntrldir/$fn  \
-		-n $certdir/clientcert.pem -vDHR 0 9930 /tmp/qmail-test/tcpclient.imap \
+		-n $certdir/clientcert.pem -vDHR 0 9930 $testdir/tcpclient.imap \
 		2>$logdir/pop3d-ssl/imapd-ssl.log
 	if [ $? -eq 0 ] ; then
 		tm2=$(date +"%s.%4N")
@@ -3484,6 +3670,459 @@ do_admin_server_tests()
 	/bin/rm -f $cntrldir/host.master $cntrldir/host.cntrl
 }
 
+do_vlimit_tests()
+{
+	# Test the following
+	# authindi, vchkpass: domain expiry, password expiry
+	# authpgsql: gid mask
+	# iauth: size, count limit
+	# inquerytest: display limits
+	# ProcessInFifo.c: get limits
+	# sql_getpw: gid mask
+	# vadduser, vmoduser: defaultquota, defaultmaxmsgcount
+	# vsetuserquota: defaultquota
+	#
+	printf "\r%126s\n" " "
+	echo "Starting domain limit tests"
+
+	tm1=$(date +"%s.%4N")
+	sudo touch $qmaildir/domains/$domain1/.domain_limits
+	sudo chown indimail:indimail $qmaildir/domains/$domain1/.domain_limits
+	$sudo env - \
+		PATH=/bin:/usr/bin:/usr/sbin \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vmoddomain -l 0 $domain1
+	ret1=$?
+	$sudo ls $qmaildir/domains/$domain1/.domain_limits >/dev/null 2>&1
+	[ $? -ne 0 ] && l1=0 || l1=1
+	$sudo env - \
+		PATH=/bin:/usr/bin:/usr/sbin \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vmoddomain -l 1 $domain1
+	ret2=$?
+	$sudo ls $qmaildir/domains/$domain1/.domain_limits >/dev/null
+	[ $? -eq 0 ] && l2=0 || l2=1
+	tm2=$(date +"%s.%4N")
+	if [ $ret1 -eq 0 -a $ret2 -eq 0 -a $l1 -eq 0 -a $l2 -eq 0 ] ; then
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		tcount=$(expr $tcount + 1)
+		printf "\r  testing vmoddomain enable domain limits       succeeded %55s [%.4f sec]\n" " " "$secs"
+		print_pct
+	else
+		echo "ret1=$ret1, ret2=$ret2, l1=$l1, l2=$l2"
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		fcount=$(expr $fcount + 1)
+		echo  " testing vmoddomain enable domain limits       failed [%.4f sec]" "$secs"
+		[ -z "$failed" ] && failed="test vmoddomain limits" || failed="$failed, test vmoddomain limits"
+		[ $continue_on_err -eq 0 ] && exit 1 || return 0
+	fi
+	tm1=$(date +"%s.%4N")
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vlimit -Q 50m $domain1
+	ret1=$?
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vlimit -q 5m $domain1
+	ret2=$?
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vlimit -s $domain1 > $tmpdir/vlimit.out
+	ret3=$?
+	tm2=$(date +"%s.%4N")
+	t1=$(grep "Max Domain Quota" $tmpdir/vlimit.out|awk '{print $5}')
+	t2=$(grep "Default User Quota" $tmpdir/vlimit.out|awk '{print $5}')
+	#Max Domain Quota     :     104857600
+	#Default User Quota   :       5242880
+	if [ $ret1 -eq 0 -a $ret2 -eq 0 -a $ret3 -eq 0 -a "$t1" = "52428800" -a "$t2" = "5242880" ] ; then
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		tcount=$(expr $tcount + 1)
+		printf "\r  testing vlimit set domain/user quota          succeeded %55s [%.4f sec]\n" " " "$secs"
+		print_pct
+	else
+		echo "ret1=$ret1, ret2=$ret2, ret3=$ret3, t1=$t1, t2=$t2"
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		fcount=$(expr $fcount + 1)
+		echo "  testing vlimit set domain/user quota failed [%.4f sec]" "$secs"
+		[ -z "$failed" ] && failed="test vlimit -qQ" || failed="$failed, test vlimit -qQ"
+		[ $continue_on_err -eq 0 ] && exit 1 || return 0
+	fi
+	/bin/rm -f $tmpdir/vlimit.out
+
+	# test setting default user quota
+	tm1=$(date +"%s.%4N")
+	t1="$password1""md5"
+	create_plain_user $testuser1 $t1 MD5 >/dev/null 2>&1
+	quota=$($sudo env - \
+		PATH=/bin:/usr/bin \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vuserinfo -q $testuser1 | head -1 |cut -d: -f2|awk '{print $1}')
+	tm2=$(date +"%s.%4N")
+
+	if [ "$quota" = "5242880" ] ; then
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		tcount=$(expr $tcount + 1)
+		printf "\r  testing vadduser set default user quota       succeeded %55s [%.4f sec]\n" " " "$secs"
+		print_pct
+	else
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		fcount=$(expr $fcount + 1)
+		echo
+		echo "quota=$quota"
+		echo "  testing vadduser set default user quota failed [%.4f sec]" "$secs"
+		[ -z "$failed" ] && failed="test vadduser set defaultquota" || failed="$failed, test vadduser set defaultquota"
+		[ $continue_on_err -eq 0 ] && exit 1 || return 0
+	fi
+
+	# test disable change passwd
+	tm1=$(date +"%s.%4N")
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vlimit -g d $domain1
+	ret1=$?
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+		DOMAIN_LIMITS=1 \
+	vpasswd $testuser1 $password1 2>$tmpdir/vpasswd.out
+	ret2=$?
+	cat $tmpdir/vpasswd.out | grep "User not allowed to change passwd" >/dev/null 2>&1
+	ret3=$?
+	tm2=$(date +"%s.%4N")
+	if [ $ret1 -eq 0 -a $ret2 -ne 0 -a $ret3 -eq 0 ] ; then
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		tcount=$(expr $tcount + 1)
+		printf "\r  testing vlimit disable password change        succeeded %55s [%.4f sec]\n" " " "$secs"
+		print_pct
+		/bin/rm -f $tmpdir/vpasswd.out
+	else
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		fcount=$(expr $fcount + 1)
+		echo "  testing vlimit disable password change failed [%.4f sec]" "$secs"
+		if [ $prompt -eq 1 ] ; then
+			(
+			echo "ret1=$ret1, ret2=$ret2, ret3=$ret3"
+			cat $tmpdir/vpasswd.out
+			) |less
+		fi
+		/bin/rm -f $tmpdir/vpasswd.out
+		[ -z "$failed" ] && failed="test vlimit disable change password" || failed="$failed, test vlimit disable change password"
+		[ $continue_on_err -eq 0 ] && exit 1 || return 0
+	fi
+
+	> $servicedir/smtpd/variables/CHECKSENDER
+	echo 1 > $servicedir/smtpd/variables/DOMAIN_LIMITS
+	echo 1 > $servicedir/imapd/variables/DOMAIN_LIMITS
+	echo 1 > $servicedir/pop3d/variables/DOMAIN_LIMITS
+	/bin/rm -f $servicedir/smtpd/variables/QUERY_CACHE \
+		$servicedir/imapd/variables/QUERY_CACHE \
+		$servicedir/pop3d/variables/QUERY_CACHE
+	$sudo svc -r $servicedir/smtpd $servicedir/imapd $servicedir/pop3d
+	check_service pop3d 3
+	/bin/rm -f $servicedir/smtpd/variables/DOMAIN_LIMITS \
+		$servicedir/imapd/variables/DOMAIN_LIMITS \
+		$servicedir/pop3d/variables/DOMAIN_LIMITS
+
+	# disable SMTP check
+	$sudo svc -a $servicedir/smtpd/log
+	swaks -S --to $testuser1 --from $testuser1 --server 127.0.0.1 \
+		--port $smtp_port --a LOGIN -au $testuser1 -ap "$t1" > $tmpdir/swaks.out
+	ret1=$?
+	# disable smtp
+	tm1=$(date +"%s.%4N")
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vlimit -g s $domain1
+	ret2=$?
+	swaks -S --to $testuser1 --from $testuser1 --server 127.0.0.1 \
+		--port $smtp_port --a LOGIN -au $testuser1 -ap "$t1" > $tmpdir/swaks.out 2>&1
+	ret3=$?
+	grep "553-Sorry, this account cannot use SMTP (#5.7.1)" $tmpdir/swaks.out >/dev/null
+	ret4=$?
+	tm2=$(date +"%s.%4N")
+	if [ $ret1 -eq 0 -a $ret2 -eq 0 -a $ret3 -ne 0 -a $ret4 -eq 0 ] ; then
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		tcount=$(expr $tcount + 1)
+		printf "\r  testing vlimit disable SMTP authentication    succeeded %55s [%.4f sec]\n" " " "$secs"
+		print_pct
+		/bin/rm -f $tmpdir/swaks.out
+	else
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		fcount=$(expr $fcount + 1)
+		echo "  testing vlimit disable SMTP authentication failed [%.4f sec]" "$secs"
+		if [ $prompt -eq 1 ] ; then
+			(
+			echo "ret1=$ret1, ret2=$ret2, ret3=$ret3, ret4=$ret4"
+			cat $tmpdir/swaks.out
+			) |less
+		fi
+		/bin/rm -f $tmpdir/swaks.out
+		[ -z "$failed" ] && failed="test vlimit disable smtp" || failed="$failed, test vlimit disable smtp"
+		[ $continue_on_err -eq 0 ] && exit 1 || return 0
+	fi
+
+	# disable IMAP authentication
+	delete_relay 2>$tmpdir/relay.out
+	auth_imap $testuser1 $t1 "PLAIN" 2>$tmpdir/imapd.out
+	ret1=$?
+	# disable imap
+	tm1=$(date +"%s.%4N")
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vlimit -g i $domain1
+	ret2=$?
+	tm2=$(date +"%s.%4N")
+	$sudo svc -a $servicedir/imapd/log
+	auth_imap $testuser1 $t1 "PLAIN" 2>$tmpdir/imapd.out
+	grep "authindi: warn: imap disabled for this account" $logdir/imapd/current >/dev/null
+	ret4=$?
+	if [ $ret1 -eq 0 -a $ret2 -eq 0 -a $ret3 -ne 0 -a $ret4 -eq 0 ] ; then
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		tcount=$(expr $tcount + 1)
+		printf "\r  testing vlimit disable IMAP authentication    succeeded %55s [%.4f sec]\n" " " "$secs"
+		print_pct
+		/bin/rm -f $tmpdir/imapd.out $tmpdir/relay.out
+	else
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		fcount=$(expr $fcount + 1)
+		echo "  testing vlimit disable IMAP authentication failed [%.4f sec]" "$secs"
+		if [ $prompt -eq 1 ] ; then
+			(
+			echo "ret1=$ret1, ret2=$ret2, ret3=$ret3, ret4=$ret4"
+			cat $tmpdir/imapd.out
+			) |less
+		fi
+		/bin/rm -f $tmpdir/imapd.out $tmpdir/relay.out
+		[ -z "$failed" ] && failed="test vlimit disable imap" || failed="$failed, test vlimit disable imap"
+		[ $continue_on_err -eq 0 ] && exit 1 || return 0
+	fi
+	r1=$(check_relay 2>/dev/null|awk '{print $1}')
+	ret6=$?
+	
+	# disable POP3 authentication
+	delete_relay 2>$tmpdir/relay.out
+	auth_pop3 $testuser1 $t1 "PLAIN" 2>$tmpdir/pop3d.out
+	ret1=$?
+	# disable pop3
+	tm1=$(date +"%s.%4N")
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vlimit -g p $domain1
+	ret2=$?
+	tm2=$(date +"%s.%4N")
+	$sudo svc -a $servicedir/pop3d/log
+	auth_pop3 $testuser1 $t1 "PLAIN" 2>$tmpdir/pop3d.out
+	grep "authindi: warn: pop3 disabled for this account" $logdir/pop3d/current >/dev/null
+	ret4=$?
+	if [ $ret1 -eq 0 -a $ret2 -eq 0 -a $ret3 -ne 0 -a $ret4 -eq 0 ] ; then
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		tcount=$(expr $tcount + 1)
+		printf "\r  testing vlimit disable POP3 authentication    succeeded %55s [%.4f sec]\n" " " "$secs"
+		print_pct
+		/bin/rm -f $tmpdir/pop3d.out $tmpdir/relay.out
+	else
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		fcount=$(expr $fcount + 1)
+		echo "  testing vlimit disable POP3 authentication failed [%.4f sec]" "$secs"
+		if [ $prompt -eq 1 ] ; then
+			(
+			echo "ret1=$ret1, ret2=$ret2, ret3=$ret3, ret4=$ret4"
+			cat $tmpdir/pop3d.out
+			echo ====================
+			cat $logdir/pop3d/current
+			) |less
+		fi
+		/bin/rm -f $tmpdir/pop3d.out $tmpdir/relay.out
+		[ -z "$failed" ] && failed="test vlimit disable pop3" || failed="$failed, test vlimit disable pop3"
+		[ $continue_on_err -eq 0 ] && exit 1 || return 0
+	fi
+	r2=$(check_relay 2>/dev/null|awk '{print $1}')
+	ret7=$?
+
+	# disable RELAY
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vlimit -g i -T $domain1
+	ret1=$?
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vlimit -g p -T $domain1
+	ret2=$?
+
+	delete_relay 2>$tmpdir/relay.out
+	tm1=$(date +"%s.%4N")
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vlimit -g r $domain1
+	ret3=$?
+	$sudo svc -a $servicedir/imapd/log
+	auth_imap $testuser1 $t1 "PLAIN" 2>$tmpdir/imapd.out
+	ret4=$?
+	$sudo svc -a $servicedir/pop3d/log
+	auth_pop3 $testuser1 $t1 "PLAIN" 2>$tmpdir/pop3d.out
+	ret5=$?
+	r3=$(check_relay 2>/dev/null |awk '{print $1}')
+	ret8=$?
+	/bin/rm -f $tmpdir/relay.out $tmpdir/imapd.out $tmpdir/pop3d.out
+	tm2=$(date +"%s.%4N")
+	if [ $ret1 -eq 0 -a $ret2 -eq 0 -a $ret3 -eq 0 -a $ret4 -eq 0 -a $ret4 -eq 0 \
+			-a $ret6 -eq 0 -a $ret7 -eq 0 -a $ret8 -eq 0 -a "$r1" = "$testuser1" \
+				-a "$r2" = "$testuser1" -a -z "$r3"] ; then
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		tcount=$(expr $tcount + 1)
+		printf "\r  testing vlimit disable relaying               succeeded %55s [%.4f sec]\n" " " "$secs"
+		print_pct
+	else
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		fcount=$(expr $fcount + 1)
+		echo "  testing vlimit disable relaying            failed [%.4f sec]\n" "$secs"
+		if [ $prompt -eq 1 ] ; then
+			(
+			echo "ret1=$ret1, ret2=$ret2, ret3=$ret3, ret4=$ret4, ret5=$ret5, ret6=$ret6, ret7=$ret7, ret8=$ret8"
+			echo "r1=$r1"
+			echo "r2=$r2"
+			echo "r3=$r3"
+			)|less
+		fi
+		[ -z "$failed" ] && failed="test vlimit disable relay" || failed="$failed, test vlimit disable relay"
+		[ $continue_on_err -eq 0 ] && exit 1 || return 0
+	fi
+
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vlimit -g s -T $domain1
+
+	# domain expiry
+	tm1=$(date +"%s.%4N")
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vlimit -n -1 $domain1
+	ret1=$?
+	swaks -S --to $testuser1 --from $testuser1 --server 127.0.0.1 \
+		--port $smtp_port --a LOGIN -au $testuser1 -ap "$t1" > $tmpdir/swaks.out 2>&1
+	ret2=$?
+	grep "553-Sorry, your domain has expired (#5.7.1)" $tmpdir/swaks.out >/dev/null
+	ret3=$?
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vlimit -e -1 $domain1
+	ret4=$?
+	tm2=$(date +"%s.%4N")
+	if [ $ret1 -eq 0 -a $ret2 -ne 0 -a $ret3 -eq 0 -a $ret4 -eq 0 ] ; then
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		tcount=$(expr $tcount + 1)
+		printf "\r  testing vlimit set domain expiry              succeeded %55s [%.4f sec]\n" " " "$secs"
+		print_pct
+		/bin/rm -f $tmpdir/swaks.out
+	else
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		fcount=$(expr $fcount + 1)
+		echo "  testing vlimit set domain expiry failed [%.4f sec]" "$secs"
+		if [ $prompt -eq 1 ] ; then
+			(
+			echo "ret1=$ret1, ret2=$ret2, ret3=$ret3, ret4=$ret4"
+			cat $tmpdir/swaks.out
+			echo ====================
+			cat $logdir/smtpd/current
+			) |less
+		fi
+		/bin/rm -f $tmpdir/swaks.out
+		[ -z "$failed" ] && failed="test vlimit set domain expiry" || failed="$failed, test vlimit set domain expiry"
+		[ $continue_on_err -eq 0 ] && exit 1 || return 0
+	fi
+	
+	# password expiry
+	tm1=$(date +"%s.%4N")
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vlimit -N -1 $domain1
+	ret1=$?
+	swaks -S --to $testuser1 --from $testuser1 --server 127.0.0.1 \
+		--port $smtp_port --a LOGIN -au $testuser1 -ap "$t1" > $tmpdir/swaks.out 2>&1
+	ret2=$?
+	grep "553-Sorry, your password has expired (#5.7.1)" $tmpdir/swaks.out >/dev/null
+	ret3=$?
+	$sudo setuidgid indimail env - \
+		PATH="/bin:/usr/bin" \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+	vlimit -t -1 $domain1
+	ret4=$?
+	tm2=$(date +"%s.%4N")
+	if [ $ret1 -eq 0 -a $ret2 -ne 0 -a $ret3 -eq 0 -a $ret4 -eq 0 ] ; then
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		tcount=$(expr $tcount + 1)
+		printf "\r  testing vlimit set password expiry            succeeded %55s [%.4f sec]\n" " " "$secs"
+		print_pct
+		/bin/rm -f $tmpdir/swaks.out
+	else
+		secs=$(echo $tm1 $tm2 | awk '{printf("%0.4f\n", $2-$1)}')
+		fcount=$(expr $fcount + 1)
+		echo "  testing vlimit set password expiry failed [%.4f sec]" "$secs"
+		if [ $prompt -eq 1 ] ; then
+			(
+			echo "ret1=$ret1, ret2=$ret2, ret3=$ret3, ret4=$ret4"
+			cat $tmpdir/swaks.out
+			echo ====================
+			cat $logdir/smtpd/current
+			) |less
+		fi
+		/bin/rm -f $tmpdir/swaks.out
+		[ -z "$failed" ] && failed="test vlimit set password expiry" || failed="$failed, test vlimit set password expiry"
+		[ $continue_on_err -eq 0 ] && exit 1 || return 0
+	fi
+}
+
 usage()
 {
 	echo "testindimail [-y|--nprompt]" 1>&2
@@ -3731,7 +4370,7 @@ failed=""
 if [ -f $testdir/itotal.count ] ; then
 	total_tests=$(cat $testdir/itotal.count)
 else
-	total_tests=1315
+	total_tests=1328
 fi
 prompt=1
 continue_on_err=0
@@ -3830,13 +4469,25 @@ delete_user $testuser3 >/dev/null 2>&1
 $sudo svc -2 $servicedir/inlookup.infifo
 check_service inlookup.infifo
 
+$sudo setuidgid indimail env - \
+	PATH="/bin:/usr/bin" \
+	ASSIGNDIR=$sysconfdir/users \
+	SYSCONFDIR=$sysconfdir \
+	CONTROLDIR=$cntrldir \
+vlimit -D $domain1 >/dev/null 2>&1
 do_plain_cram_user_tests
 
 do_scram_user_tests
 
+# create testuser1, testuser2 for do_admin_server_tests and do_vlimit_tests
 t1="$password1""md5"
+t2="$password2""md5"
 create_plain_user $testuser1 $t1 MD5 >/dev/null 2>&1
+create_plain_user $testuser2 $t2 MD5 >/dev/null 2>&1
 do_admin_server_tests
+
+delete_user $testuser1 >/dev/null 2>&1
+do_vlimit_tests
 
 printf "\r%126s\n" " "
 echo "Testing domain deletion"
@@ -3875,6 +4526,9 @@ exit 0
 
 #
 # $Log: testindimail-virtual,v $
+# Revision 1.28  2024-05-28 00:23:38+05:30  Cprogrammer
+# added tests for vlimits
+#
 # Revision 1.27  2024-05-24 14:53:22+05:30  Cprogrammer
 # updated test script
 #

--- a/indimail-x/vadduser.9
+++ b/indimail-x/vadduser.9
@@ -233,9 +233,9 @@ system hard quota limit is set. The default limit is either 50M or what
 ever is set via --enable-hardquota.  If set to NOQUOTA then the user will
 have no quota limit.
 
-If the domain has domain limits set using vmoddomlimits(1), then domain
-limits apply. Also, this option will not be allowed if permission for
-creating quota is disabled in domain limits.
+If the domain has domain limits set using vlimit(1), then domain limits
+apply. Also, this option will not be allowed if permission for creating
+quota is disabled in domain limits.
 
 You can use the suffix k/K, m/M, g/G to specify quota in Kb, Mb or Gb.
 
@@ -281,4 +281,4 @@ fail, a diagnostic message is printed.
 
 .SH "SEE ALSO"
 printdir(1), vreorg(8), vdeluser(1), vpasswd(1), vmoduser(1),
-vmoddomlimits(1)
+vlimit(1)

--- a/indimail-x/vadduser.c
+++ b/indimail-x/vadduser.c
@@ -1,5 +1,5 @@
 /*
- * $Id: vadduser.c,v 1.15 2024-05-17 16:25:48+05:30 mbhangui Exp mbhangui $
+ * $Id: vadduser.c,v 1.16 2024-05-27 22:53:14+05:30 Cprogrammer Exp mbhangui $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -64,7 +64,7 @@
 #include "common.h"
 
 #ifndef	lint
-static char     rcsid[] = "$Id: vadduser.c,v 1.15 2024-05-17 16:25:48+05:30 mbhangui Exp mbhangui $";
+static char     rcsid[] = "$Id: vadduser.c,v 1.16 2024-05-27 22:53:14+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 #define FATAL   "vadduser: fatal: "
@@ -138,7 +138,7 @@ main(int argc, char **argv)
 	gid_t           gid, gidtmp;
 #ifdef ENABLE_DOMAIN_LIMITS
 	int             domain_limits;
-	struct vlimits  limits;
+	struct vlimits  limits = { 0 };
 #endif
 	struct substdio ssin;
 #ifdef HAVE_GSASL
@@ -179,10 +179,10 @@ main(int argc, char **argv)
 		strerr_die3x(100, "vadduser: domain ", real_domain, " with uid 0");
 #ifdef ENABLE_DOMAIN_LIMITS
 	if (!stralloc_copys(&tmpbuf, domain_dir) ||
-			!stralloc_catb(&tmpbuf, ".domain_limits", 14) ||
+			!stralloc_catb(&tmpbuf, "/.domain_limits", 15) ||
 			!stralloc_0(&tmpbuf))
 		die_nomem();
-	domain_limits = ((access(tmpbuf.s, F_OK) && !env_get("DOMAIN_LIMITS")) ? 0 : 1);
+	domain_limits = !access(tmpbuf.s, F_OK);
 	if (domain_limits && vget_limits(real_domain, &limits)) {
 		strerr_warn2("vadduser: Unable to get domain limits for ", real_domain, 0);
 		return (1);
@@ -588,6 +588,10 @@ get_options(int argc, char **argv, char **base_path, int *users_per_level,
 
 /*
  * $Log: vadduser.c,v $
+ * Revision 1.16  2024-05-27 22:53:14+05:30  Cprogrammer
+ * initialize struct vlimits
+ * fix .domain_limits path
+ *
  * Revision 1.15  2024-05-17 16:25:48+05:30  mbhangui
  * fix discarded-qualifier compiler warnings
  *

--- a/indimail-x/vchkpass.c
+++ b/indimail-x/vchkpass.c
@@ -1,5 +1,5 @@
 /*
- * $Id: vchkpass.c,v 1.20 2024-05-10 11:43:51+05:30 mbhangui Exp mbhangui $
+ * $Id: vchkpass.c,v 1.21 2024-05-27 22:53:42+05:30 Cprogrammer Exp mbhangui $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -44,7 +44,7 @@
 #include "runcmmd.h"
 
 #ifndef lint
-static char     sccsid[] = "$Id: vchkpass.c,v 1.20 2024-05-10 11:43:51+05:30 mbhangui Exp mbhangui $";
+static char     sccsid[] = "$Id: vchkpass.c,v 1.21 2024-05-27 22:53:42+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 #ifdef AUTH_SIZE
@@ -82,7 +82,7 @@ main(int argc, char **argv)
 	struct passwd  *pw;
 #ifdef ENABLE_DOMAIN_LIMITS
 	time_t          curtime;
-	struct vlimits  limits;
+	struct vlimits  limits = { 0 };
 #endif
 
 	if (argc < 2)
@@ -428,6 +428,9 @@ main(int argc, char **argv)
 
 /*
  * $Log: vchkpass.c,v $
+ * Revision 1.21  2024-05-27 22:53:42+05:30  Cprogrammer
+ * initialize struct vlimits
+ *
  * Revision 1.20  2024-05-10 11:43:51+05:30  mbhangui
  * fix discarded-qualifier compiler warnings
  *

--- a/indimail-x/vdelivermail.9
+++ b/indimail-x/vdelivermail.9
@@ -278,6 +278,6 @@ for all temporary error occurs during mail delivery and without the error,
 the mail would have got delivered
 
 .SH "SEE ALSO"
-vmoduser(1), vsetuserquota(1), vmoddomlimits(1),
+vmoduser(1), vsetuserquota(1), vlimit(1),
 qmail-lspawn(8), spawn-filter(8), qmail-local(8),
 qmail-remote(8), maildirdeliver(1), ismaildup(1), strftime(3)

--- a/indimail-x/vlimit.1
+++ b/indimail-x/vlimit.1
@@ -1,3 +1,4 @@
+.\" vim: tw=75
 .TH vlimit 1
 .SH NAME
 vlimit \- Set / Modify Domain wide Limits
@@ -11,104 +12,147 @@ vlimit \- Set / Modify Domain wide Limits
 
 .SH OPTIONS
 .PP
-.TP
+
+.TP 3
 \fB\-v\fR
 display the indimail version number
+
 .TP
-\fB\-S\fR
+\fB\-s\fR
 show current settings
+
 .TP
 \fB\-D\fR
 delete limits for this domain, i.e. switch to default limits)
+
+.TP
+\fB\-e\fR \fIedate\fR | \fB\-n\fR \fIdays\fR
+Set the domain expiry date to \fIedate\fR in \fBddmmyyyyHHMMSS\fR format or
+\fIdays\fR from today. Use -1 for \fIedate\fR to disable domain expiry.
+\fIdays\fR can be negative to expire the domain in the past.
+
+.TP
+\fB\-t\fR \fIedate\fR | \fB\-N\fR \fIdays\fR
+Set the password expiry date to \fIedate\fR in \fBddmmyyyyHHMMSS\fR format or
+\fIdays\fR from today. Use -1 for \fIedate\fR to disable password expiry.
+\fIdays\fR can be negative to expire the password in the past.
+
 .TP
 \fB\-Q\fR \fIquota\fR
-set domain quota limit. You can use the suffix k/K, m/M, g/G to specify the quota
-in Kb, Mb, or Gb.
+set domain quota limit. You can use the suffix k/K, m/M, g/G to specify the
+quota in Kb, Mb, or Gb.
+
 .TP
 \fB\-M\fR \fIcount\fR
 set domain max msg count limit
+
 .TP
 \fB\-q\fR \fIquota\fR
-set default user quota limit. You can use the suffix k/K, m/M, g/G to specify the quota
-in Kb, Mb, or Gb. Specify \fBNOQUOTA\fR if you want to have unlimited quota.
+set default user quota limit. You can use the suffix k/K, m/M, g/G to
+specify the quota in Kb, Mb, or Gb. Specify \fBNOQUOTA\fR if you want to
+have unlimited quota.
+
 .TP
 \fB\-m\fR \fIcount\fR
 set default user max msg count limit
+
 .TP
 \fB\-P\fR \fIcount\fR
 set max amount of pop accounts limit
+
 .TP
 \fB\-A\fR \fIcount\fR
 set max amount of aliases limit
+
 .TP
 \fB\-F\fR \fIcount\fR
 set max amount of forwards limit
+
 .TP
 \fB\-R\fR \fIcount\fR
 set max amount of autoresponders
+
 .TP
 \fB\-L\fR \fIcount\fR
 set max amount of mailing lists
-.PP
-the following options are bit flags in the gid int field
 
-\fB\-g\fR \fIgid_flags\fR
-set flags, see below
 .PP
+The following options are bit flags in the gid int field
+
+.TP 3
+\fB\-g\fR \fIgid_flags\fR
+set flags. See below
+
 gid_flags:
- u set no dialup flag
- d set no password changing flag
- p set no pop access flag
- s set no smtp access flag
- w set no web mail access flag
- i set no imap access flag
- r set no external relay flag
- x clear all flags
+ u - set no dialup flag
+ d - set no password changing flag
+ s - set no smtp access flag
+ i - set no imap access flag
+ p - set no pop access flag
+ w - set no web mail access flag
+ r - set no external relay flag
+ x - clear all flags
+
+.PP
+.TP 3
+\fB\-T\fR
+Toggle bit flag for -g option
 
 .PP
 the following options are bit flags for non postmaster admins
-.TP
+
+.TP 3
 \fB\-p\fR \fIperm_flags\fR
 set pop account flags
+
 .TP
 \fB\-a\fR \fIperm_flags\fR
 set alias flags
+
 .TP
 \fB\-f\fR \fIperm_flags\fR
 set forward flags
+
 .TP
 \fB\-r\fR \fIperm_flags\fR
 set autoresponder flags
+
 .TP
 \fB\-l\fR \fIperm_flags\fR
 set mailing list flags
+
 .TP
 \fB\-u\fR \fIperm_flags\fR
 set mailing list users flags
+
 .TP
 \fB\-o\fR \fIperm_flags\fR
 set mailing list moderators flags
+
 .TP
 \fB\-x\fR \fIperm_flags\fR
 set domain quota flags
+
 .TP
 \fB\-z\fR \fIperm_flags\fR
 set default quota flags
 
 .PP
+.TP 2
 perm_flags:
- a set deny all flag
- c set deny create flag
- m set deny modify flag
- d set deny delete flag
+ a - set deny all flag
+ c - set deny create flag
+ m - set deny modify flag
+ d - set deny delete flag
 
 .SH RETURN VALUE
  0 if all steps were successful. 
  1 if any error occurred
 
 .SH NOTES
-domain limits is work in progress and not fully implemented. For \fBvlimit\fR to work, domain
-limits need to be enabled for a domain using \fBvmoddomain(1)\fR.
+domain limits is work in progress and not fully implemented. For
+\fBvlimit\fR(1) to work, domain limits need to be enabled for a domain
+using \fBvmoddomain(1)\fR.
 
 .SH "SEE ALSO"
 vmoddomain(1)

--- a/indimail-x/vlimits.h
+++ b/indimail-x/vlimits.h
@@ -1,5 +1,8 @@
 /*
  * $Log: vlimits.h,v $
+ * Revision 1.4  2024-05-27 08:05:16+05:30  Cprogrammer
+ * changed data type of variables to long
+ *
  * Revision 1.3  2024-05-17 16:25:48+05:30  mbhangui
  * fix discarded-qualifier compiler warnings
  *
@@ -30,11 +33,11 @@ struct vlimits {
       /* max service limits */
       long      domain_expiry;
       long      passwd_expiry;
-      int       maxpopaccounts;
-      int       maxaliases;
-      int       maxforwards;
-      int       maxautoresponders;
-      int       maxmailinglists;
+      long      maxpopaccounts;
+      long      maxaliases;
+      long      maxforwards;
+      long      maxautoresponders;
+      long      maxmailinglists;
 
       /* quota & message count limits */
       umdir_t   diskquota;			/*- domain quota */

--- a/indimail-x/vmoduser.9
+++ b/indimail-x/vmoduser.9
@@ -46,7 +46,7 @@ the existing quota by amount specified by \fIquota\fR. You can use k/K,
 m/M, g/G for kibibytes, mebibytes and gibibytes respectively, when
 specifying a value for \fIquota\fR.
 
-If the domain has domain limits set using vmoddomlimits(1), then domain
+If the domain has domain limits set using vlimit(1), then domain
 limits apply. Also, this option will not be allowed if permission for
 modifying quota is disabled in domain limits.
 
@@ -241,5 +241,5 @@ V_USER3	0x800
 0 in case of success and non-zero in case of any failure.
 
 .SH "SEE ALSO"
-vsetuserquota(1), vpasswd(1), vmoddomlimits(1), resetquota(8),
+vsetuserquota(1), vpasswd(1), vlimit(1), resetquota(8),
 vdelivermail(8), strftime(3), incrypt(1), crypt(3), gsasl(1)

--- a/indimail-x/vmoduser.c
+++ b/indimail-x/vmoduser.c
@@ -1,5 +1,5 @@
 /*
- * $Id: vmoduser.c,v 1.22 2024-05-17 16:25:48+05:30 mbhangui Exp mbhangui $
+ * $Id: vmoduser.c,v 1.23 2024-05-27 22:53:57+05:30 Cprogrammer Exp mbhangui $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -60,7 +60,7 @@
 #include "get_hashmethod.h"
 
 #ifndef	lint
-static char     sccsid[] = "$Id: vmoduser.c,v 1.22 2024-05-17 16:25:48+05:30 mbhangui Exp mbhangui $";
+static char     sccsid[] = "$Id: vmoduser.c,v 1.23 2024-05-27 22:53:57+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 #define FATAL   "vmoduser: fatal: "
@@ -362,7 +362,7 @@ main(int argc, char **argv)
 #endif
 #ifdef ENABLE_DOMAIN_LIMITS
 	static stralloc TheDir = {0};
-	struct vlimits  limits;
+	struct vlimits  limits = { 0 };
 	int             domain_limits;
 #endif
 #ifdef HAVE_GSASL
@@ -665,6 +665,9 @@ main(int argc, char **argv)
 
 /*
  * $Log: vmoduser.c,v $
+ * Revision 1.23  2024-05-27 22:53:57+05:30  Cprogrammer
+ * initialize struct vlimits
+ *
  * Revision 1.22  2024-05-17 16:25:48+05:30  mbhangui
  * fix discarded-qualifier compiler warnings
  *

--- a/indimail-x/vsetuserquota.1
+++ b/indimail-x/vsetuserquota.1
@@ -1,3 +1,4 @@
+.\" vim: tw=75
 .TH vsetuserquota 1
 .SH NAME
 vsetuserquota \- Set quota for a user in a virtual domain
@@ -11,32 +12,35 @@ vsetuserquota \- Set quota for a user in a virtual domain
 .I quota_in_bytes
 
 .SH DESCRIPTION
-\fBvsetuserquota\fR changes a users hard quota limit. \fB--enable-hardquota=y\fR must be set
-during  indimail configuration for this to have any effect. Default configuration sets
-hard quota on. \fBvsetuserquota\fR has setuid bit set and must be run as root or indimail user.
+\fBvsetuserquota\fR changes a users hard quota limit. \fBvsetuserquota\fR
+has setuid bit set and must be run as root or indimail user.
 
 .SH OPTIONS
 .TP
 \fB\-v\fR
 Set verbose mode.
+
 .TP
 \fIemail_address\fR
 The email address of the user. 
+
 .TP
 \fIquota_in_bytes\fR
-The hard quota limit in bytes. Abbrievations can be used for kilobytes, megabytes and
-gigabytes. For example \fBvsetuserquota\fR user@domain 5m will set the quota to 5 mega
-bytes. Or \fBvsetuserquota\fR user@domain 2k will set the quota to 2k. \fBvsetuserquota\fR
-user@domain NOQUOTA will turn off all quota checking for that user.
+The hard quota limit in bytes. Abbrievations can be used for kilobytes,
+megabytes and gigabytes. For example \fBvsetuserquota\fR user@domain 5m
+will set the quota to 5 mega bytes. Or \fBvsetuserquota\fR user@domain 2k
+will set the quota to 2k. \fBvsetuserquota\fR user@domain NOQUOTA will turn
+off all quota checking for that user.
 
 .PP
-If the domain has domain limits set using vmoddomlimits(1), then domain limits apply. Setting
-of quota will not be allowed if permission for modifying quota is disabled in domain limits.
+If the domain has domain limits set using vlimit(1), then domain limits
+apply. Setting of quota will not be allowed if permission for modifying
+quota is disabled in domain limits.
 
 .SH RETURN VALUE
-0 if all steps were successful, non-zero otherwise. If any of the steps fail, a diagnostic
-message is printed.
+0 if all steps were successful, non-zero otherwise. If any of the steps
+fail, a diagnostic message is printed.
 
 .SH "SEE ALSO"
 
-vadduser(1), vmoduser(1), resetquota(8), vmoddomlimits(1)
+vadduser(1), vmoduser(1), resetquota(8), vlimit(1)

--- a/indimail-x/vsetuserquota.c
+++ b/indimail-x/vsetuserquota.c
@@ -1,5 +1,8 @@
 /*
  * $Log: vsetuserquota.c,v $
+ * Revision 1.6  2024-05-27 22:54:09+05:30  Cprogrammer
+ * initialize struct vlimits
+ *
  * Revision 1.5  2024-05-24 14:52:01+05:30  Cprogrammer
  * print current usage in bytes on stdout
  *
@@ -34,7 +37,6 @@
 #ifdef HAVE_QMAIL
 #include <stralloc.h>
 #include <strerr.h>
-#include <env.h>
 #include <sgetopt.h>
 #include <qprintf.h>
 #include <subfd.h>
@@ -53,7 +55,7 @@
 #include "setuserquota.h"
 
 #ifndef	lint
-static char     sccsid[] = "$Id: vsetuserquota.c,v 1.5 2024-05-24 14:52:01+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: vsetuserquota.c,v 1.6 2024-05-27 22:54:09+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 #define FATAL   "vsetuserquota: fatal: "
@@ -120,7 +122,7 @@ main(int argc, char **argv)
 #ifdef ENABLE_DOMAIN_LIMITS
 	static stralloc tmpbuf = {0}, TheDir = {0};
 	int             domain_limits;
-	struct vlimits  limits;
+	struct vlimits  limits = { 0 };
 #endif
 
 	if (get_options(argc, argv, &email, &quota))
@@ -147,7 +149,7 @@ main(int argc, char **argv)
 			!stralloc_catb(&tmpbuf, "/.domain_limits", 15) ||
 			!stralloc_0(&tmpbuf))
 		die_nomem();
-	domain_limits = ((access(tmpbuf.s, F_OK) && !env_get("DOMAIN_LIMITS")) ? 0 : 1);
+	domain_limits = !access(tmpbuf.s, F_OK);
 #endif
 #ifdef CLUSTERED_SITE
 	if (sqlOpen_user(email, 0))


### PR DESCRIPTION
1.  ProcessInFifo.c, VlimitInLookup.c, authindi.c, authpgsql.c, iauth.c, sql_getpw.c, vadduser.c, vchkpass.c, vlimit.c, vmoduser.c, vsetuserquota.c: initialize struct vlimits
2. limits.c: fix data types to fix stack smashing
3. vlimits.h: changed data types to long
4. vlimit.c: added -T option to toggle bit field
5. vlimit.c: fixed data types
6. inquerytest: change data type to long
7. vadduser.c: fix .domain_limits path